### PR TITLE
:construction_worker: (CI) golangのlintを自動チェックするGitHub Actionsの設定を追加

### DIFF
--- a/.github/workfrows/golangcli-lint.yml
+++ b/.github/workfrows/golangcli-lint.yml
@@ -1,0 +1,45 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+jobs:
+  golangci:
+    name: golang-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true


### PR DESCRIPTION
## 概要
- mainブランチのコード品質を保つ

## やったこと
- golangのlintをgithub actinonで実行するようにした

## 意図的にやらなかったこと
- なし

## 確認したこと
- [ ] 

## やり残したこと
- testのCIも回したいが、それは別actionで後ほど対応

# 参考URL
- https://github.com/golangci/golangci-lint-action